### PR TITLE
Fix query_panels.sh influxdb host

### DIFF
--- a/query_panels.sh
+++ b/query_panels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ####Config####
-INFLUXDB_HOST="localhost:8086"
+INFLUXDB_HOST="a0d7b954-influxdb:8086"
      USERNAME="powermonitor"
      PASSWORD="password"
      DATABASE="homeassistant"


### PR DESCRIPTION
I wasn't able to get the script to work until an AI helped me figure it out. I was running the script from the terminal in studio code server. Apparently containers (add ons) within HA can't access "localhost:port," they need the actual name of the container written out.